### PR TITLE
FIX: case sensitive file path

### DIFF
--- a/app/Support/GitHub/GitHub.php
+++ b/app/Support/GitHub/GitHub.php
@@ -52,7 +52,7 @@ class GitHub implements Service
 
         // TODO: Consider filtering pushed_at date with max age
         $response = $this->github->post(static::BASE_URL . 'graphql', [
-            'query' => file_get_contents(__DIR__ . '/queries/repositories.graphql'),
+            'query' => file_get_contents(__DIR__ . '/Queries/repositories.graphql'),
             'variables' => [
                 'take' => $take,
             ],


### PR DESCRIPTION
since Unix systems (Linux/Mac) are case sensitive,
in the file `App\Support\GitHub\GitHub`, 
the file path `file_get_contents(__DIR__ . '/queries/repositories.graphql')`  throws an error.

![image](https://github.com/user-attachments/assets/a911b8bf-b910-4a11-97e4-cdc56a47fa17)
